### PR TITLE
feat(api): expose format_markdown_table

### DIFF
--- a/lua/markdown-table-mode/init.lua
+++ b/lua/markdown-table-mode/init.lua
@@ -263,4 +263,7 @@ local function setup(opts)
   })
 end
 
-return { setup = setup }
+return {
+  setup = setup,
+  format_markdown_table = format_markdown_table,
+}


### PR DESCRIPTION
With this other plugins can depend on this plugin to utilize the table formatting functionality:
```lua
local mtm = require("markdown-table-mode")
mtm.format_markdown_table()
```