### PR TITLE
fix: handle excess cells on separator line

### DIFF
--- a/lua/markdown-table-mode/init.lua
+++ b/lua/markdown-table-mode/init.lua
@@ -124,7 +124,7 @@ local function format_separator_line(cells, width)
   for i = 1, #cells do
     local left_char = cells[i]:sub(1, 1)
     local right_char = cells[i]:sub(#cells[i])
-    local num = width[i]
+    local num = width[i] or 0
     if bias then
       num = num - 2
       left_char = ' ' .. left_char


### PR DESCRIPTION
Missing width implies there's an excess cell on the separator line. Treat it as a 0 width cell so that the formatter doesn't break.

Fixes #14.